### PR TITLE
fixes call to removeFiles with no arguments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ function updated(config) {
       if (config.verbose) {
         console.log("No files to compute updates for.");
       }
-      removeFiles();
+      removeFiles(files, config);
       done();
     }
 


### PR DESCRIPTION
In the event no files were found this line would end up throwing an unintentional error due to the missing arguments for removeFiles
